### PR TITLE
Replace sed in build_header with native pattern matching

### DIFF
--- a/lib/functions/inline/build_header.sh
+++ b/lib/functions/inline/build_header.sh
@@ -18,33 +18,21 @@ build_header() {
                 # If enabled (default:true), add a configurable content header after the metadata header. The purpose of this is to enable a standardised header for stuff like post dates that should be on *most* pages, but can be disabled on pages the user considers special and wants to build out completely on their own.
                 [[ $content_header == "true" ]] && cat $config/content_header.html >> $1
                 
-                # Replace all tags with their value. Ampersands are a special character in sed, so we have to clean them up using bash string manipulation before running the sed global replace.
-                title=${title//&/\\&}
-                sed -i "s^{{title}}^$title^g" $1
+                # Replace all tags in {{this format}} with their value. We do this using Bash pattern replacement.
+                page_contents="$(cat $1)"
 
-                author=${author//&/\\&}
-                sed -i "s^{{author}}^$author^g" $1
-                
-                description=${description//&/\\&}
-                sed -i "s^{{description}}^$description^g" $1
-                
-                language=${language//&/\\&}
-                sed -i "s^{{language}}^$language^g" $1
-                
-                thumbnail=${thumbnail//&/\\&}
-                sed -i "s^{{thumbnail}}^$thumbnail^g" $1
-                
-                sed -i "s^{{published_date}}^$published_date^g" $1
-                
-                sed -i "s^{{modified_date}}^$modified_date^g" $1
-                
-                canonical_url=${canonical_url//&/\\&}
-                sed -i "s^{{canonical_url}}^$canonical_url^g" $1
-                
-                base_url=${base_url//&/\\&}
-                sed -i "s^{{base_url}}^$base_url^g" $1
-                
-                global_name=${global_name//&/\\&}
-                sed -i "s^{{global_name}}^$global_name^g" $1
+                page_contents="${page_contents//\{\{title\}\}/"$title"}"
+                page_contents="${page_contents//\{\{author\}\}/"$author"}"
+                page_contents="${page_contents//\{\{description\}\}/"$description"}"
+                page_contents="${page_contents//\{\{language\}\}/"$language"}"
+                page_contents="${page_contents//\{\{thumbnail\}\}/"$thumbnail"}"
+                page_contents="${page_contents//\{\{published_date\}\}/"$published_date"}"
+                page_contents="${page_contents//\{\{modified_date\}\}/"$modified_date"}"
+                page_contents="${page_contents//\{\{canonical_url\}\}/"$canonical_url"}"
+                page_contents="${page_contents//\{\{base_url\}\}/"$base_url"}"
+                page_contents="${page_contents//\{\{global_name\}\}/"$global_name"}"
+
+                echo "$page_contents" > $1
+                page_contents=""
         }
 }


### PR DESCRIPTION
Sed is super unsafe with inline replacement, so we should avoid using it. The use of sed to populate the page header has been replaced with Bash native pattern matching