### PR TITLE
Make deployment workflow intelligently choose to deploy to main or staging

### DIFF
--- a/.github/workflows/arise-deploy.yml
+++ b/.github/workflows/arise-deploy.yml
@@ -11,11 +11,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Allow one concurrent deployment
-concurrency:
-  group: "pages-staging"
-  cancel-in-progress: true
-
 # Default to bash
 defaults:
   run:

--- a/.github/workflows/arise-deploy.yml
+++ b/.github/workflows/arise-deploy.yml
@@ -21,13 +21,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Arise
     steps:
-      - name: Check if we should push to main or debug
+      - name: Check if we should deploy to prod or staging
         run: |
+          echo "SMART DEPLOY"
+          echo "============"
+          echo "We only want to deploy to prod if the branch that triggered this workflow is 'main'. Otherwise, we want the site to be deployed to staging..."
+          echo ""
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-              echo "OUTPUT_BRANCH=html" >> "$GITHUB_ENV" # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be pushed for production.
+              # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be deployed for production.
+              echo "OUTPUT_BRANCH=html" >> "$GITHUB_ENV"
               echo "Workflow running from main branch. Pushing results to production deployment branch (html)."
           else
-              echo "OUTPUT_BRANCH=html-staging" >> "$GITHUB_ENV" # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be pushed for staging.
+              # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be deployed for staging.
+              echo "OUTPUT_BRANCH=html-staging" >> "$GITHUB_ENV"
               echo "Workflow running from a development branch. Pushing results to staging deployment branch (html-staging)."
           fi
 

--- a/.github/workflows/arise-deploy.yml
+++ b/.github/workflows/arise-deploy.yml
@@ -26,8 +26,6 @@ jobs:
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
               echo "OUTPUT_BRANCH=html" >> "$GITHUB_ENV" # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be pushed for production.
               echo "Workflow running from main branch. Pushing results to production deployment branch (html)."
-          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-              gh run cancel "${{ github.run_id }}"
           else
               echo "OUTPUT_BRANCH=html-staging" >> "$GITHUB_ENV" # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be pushed for staging.
               echo "Workflow running from a development branch. Pushing results to staging deployment branch (html-staging)."
@@ -46,7 +44,7 @@ jobs:
         uses: s0/git-publish-subdir-action@develop
         env:
           REPO: self
-          BRANCH: {{ env.OUTPUT_BRANCH }} # If you want to change this, change it in the step above. This allows us to intelligently deploy to production from main or staging if we're on a dev branch.
+          BRANCH: ${{ env.OUTPUT_BRANCH }} # If you want to change this, change it in the step above. This allows us to intelligently deploy to production from main or staging if we're on a dev branch.
           FOLDER: arise-out # The Arise build output location. Don't change this.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Handled automatically -- Don't change this unless you're pushing to a different repo
           MESSAGE: "Commit: ({sha}) {msg}" # Copies commit msg from main to the deploy version branch

--- a/.github/workflows/arise-deploy.yml
+++ b/.github/workflows/arise-deploy.yml
@@ -21,6 +21,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Arise
     steps:
+      - name: Check if we should push to main or debug
+        run: |
+          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+              echo "OUTPUT_BRANCH=html" >> "$GITHUB_ENV" # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be pushed for production.
+              echo "Workflow running from main branch. Pushing results to production deployment branch (html)."
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+              gh run cancel "${{ github.run_id }}"
+          else
+              echo "OUTPUT_BRANCH=html-staging" >> "$GITHUB_ENV" # Feel free to change the value of OUTPUT_BRANCH. This is where Arise artefacts will be pushed for staging.
+              echo "Workflow running from a development branch. Pushing results to staging deployment branch (html-staging)."
+          fi
+
       - name: git-checkout
         uses: actions/checkout@v4
 
@@ -34,7 +46,7 @@ jobs:
         uses: s0/git-publish-subdir-action@develop
         env:
           REPO: self
-          BRANCH: html-staging # Feel free to change this. This is where Arise artefacts will be pushed.
+          BRANCH: {{ env.OUTPUT_BRANCH }} # If you want to change this, change it in the step above. This allows us to intelligently deploy to production from main or staging if we're on a dev branch.
           FOLDER: arise-out # The Arise build output location. Don't change this.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Handled automatically -- Don't change this unless you're pushing to a different repo
           MESSAGE: "Commit: ({sha}) {msg}" # Copies commit msg from main to the deploy version branch


### PR DESCRIPTION
The way the deployment workflow worked originally is that it was hardcoded to deploy to a branch `html`, so if we wanted to test changes in staging we had to manually edit the workflow.

This PR adds a check to determine whether the branch we're working on is main or not. If it's main, deployments go to production. If it's not, deployments go to staging.